### PR TITLE
Use ACTUAL_DATA_DIR environment variable instead of serverFiles a userFiles config

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -1,5 +1,3 @@
 {
-    "port": "__PORT__",
-    "serverFiles": "__DATA_DIR__/data/server-files",
-    "userFiles": "__DATA_DIR__/data/user-files"
+    "port": "__PORT__"
 }

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,6 +8,7 @@ User=__APP__
 Group=__APP__
 Environment="PATH=__PATH_WITH_NODEJS__"
 Environment="NODE_ENV=production"
+Environment="ACTUAL_DATA_DIR=__DATA_DIR__"
 WorkingDirectory=__INSTALL_DIR__/
 ExecStart=/usr/bin/yarn start
 Restart=on-failure

--- a/scripts/install
+++ b/scripts/install
@@ -33,7 +33,7 @@ yunohost service add $app --description="Local-first personal finance tool" --lo
 #=================================================
 ynh_script_progression "Adding $app's configuration..."
 
-ynh_config_add --template="config.json" --destination="$install_dir/config.json"
+ynh_config_add --template="config.json" --destination="$data_dir/data/config.json"
 
 #=================================================
 # INSTALL THE LOUNGE


### PR DESCRIPTION
### Context

Following the issue raised by CI during the update to version 24.12.0 (see [PR #49](https://github.com/YunoHost-Apps/actual_ynh/pull/49)), here is a summary of the observations.

### Description

Actual creates a `.migrate` file in the `dataDir`. This behavior is visible in the source code:  
[migrations.js#L13](https://github.com/actualbudget/actual-server/blob/master/src/migrations.js#L13C41-L13C48).

The `dataDir` variable is **not documented** in the [official configuration variables](https://actualbudget.org/docs/config/), as reported in the following issue:  
[actualbudget/docs#566](https://github.com/actualbudget/docs/issues/566).

However, this variable can be set via the environment variable `ACTUAL_CONFIG_PATH` as introduced by the following PR on the Actual side:  
[actual-server#480](https://github.com/actualbudget/actual-server/pull/480).

### Consequences

Based on `dataDir`:
- The paths `serverFiles` and `userFiles` are dynamically calculated:  
  - [serverFiles](https://github.com/actualbudget/actual-server/blob/master/src/load-config.js#L99)  
  - [userFiles](https://github.com/actualbudget/actual-server/blob/master/src/load-config.js#L100)  
  This removes the need to specify them manually.
- The location of the `.migrate` file is also derived from this variable.  
  If the app is removed without the `--purge` option, this file **is not deleted**, which can cause issues during reinstallations or updates.

cc @ericgaspar 